### PR TITLE
Remove hard dependency on Bootstrap

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -84,7 +84,6 @@
         mounted()
         {
             this.disablePrevNext();
-            console.log(this.customActiveBGColor);
         },
         computed: {
             pages : function()

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -34,8 +34,6 @@
 </template>
 
 <script>
-    import 'bootstrap/dist/css/bootstrap.css'
-
     export default {
         name : 'VuePaginateAl',
         props : {


### PR DESCRIPTION
A developer may already have Bootstrap included, and done some styling overwrites. The Bootstrap included here would then overwrite those edits again. And it would include Bootstrap twice. So it's better to let the user include Bootstrap in their own package.json.